### PR TITLE
change listen address to host default ipv4 address

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,5 +45,5 @@ grok_services:
           api_request: "{{ '{{' }}.apirequest{{ '}}' }}"
           status_code: "{{ '{{' }}.statuscode{{ '}}' }}"
     server:
-      host: "{{ ansible_eth0.ipv4.address }}"
+      host: "{{ ansible_default_ipv4.address }}"
       port: 9144


### PR DESCRIPTION
This will set the default ipv4 address from the host instead of ipv4 address from eth0 interface. Will resolve the problem when your default interface is not eth0 named